### PR TITLE
Porting IP Filter plugin to Qt 5

### DIFF
--- a/plugins/ipfilter/porting_to_qt5
+++ b/plugins/ipfilter/porting_to_qt5
@@ -1,0 +1,1 @@
+Started 11/10/16, already mostly working.


### PR DESCRIPTION
Since issues seem to be deactivated for your repository, I'm using this pull request to let you know that I'm currently porting the IP Filter plugin to Qt 5. Already got it working for the most part, needs further cleanup and polishing.

I'll upload the modifications and create a pull request once I'm done.